### PR TITLE
drop Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
-cache:
-  directories:
-    - ~/.npm
-    - node_modules/cypress/dist
+cache: npm
 
 # Trigger a push build on master and greenkeeper branches + PRs build on every branches
 # Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ stages:
 jobs:
   include:
     - stage: test
-      node_js: 6
+      node_js: 12
       script: npm run test
     - node_js: 8
       script: npm run test


### PR DESCRIPTION
Node 6 is no longer maintained and keeping dependencies up to date while supporting Node 6 is no longer manageable