### PR TITLE
fix typescript errors in test

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -11,11 +11,11 @@ const NON_VARIABLE_OPTIONS = [
   "query"
 ];
 
-export function graphql<T extends GraphQlQueryResponse>(
+export function graphql(
   request: typeof Request,
   query: string | Parameters,
   options?: Parameters
-) {
+): Promise<GraphQlQueryResponse> {
   options =
     typeof query === "string"
       ? (options = Object.assign({ query }, options))
@@ -38,9 +38,9 @@ export function graphql<T extends GraphQlQueryResponse>(
     {} as Endpoint
   );
 
-  return request<T>(requestOptions).then(response => {
+  return request(requestOptions).then(response => {
     if (response.data.errors) {
-      throw new GraphqlError<T>(requestOptions, {
+      throw new GraphqlError(requestOptions, {
         data: response.data as Required<GraphQlQueryResponse>
       });
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface graphql {
    *
    * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  <T = any>(options: Parameters): Promise<GraphQlQueryResponse>;
+  (options: Parameters): Promise<GraphQlQueryResponse>;
 
   /**
    * Sends a request based on endpoint options
@@ -17,9 +17,7 @@ export interface graphql {
    * @param {string} route Request method + URL. Example: `'GET /orgs/:org'`
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  <T = any>(query: Query, parameters?: Parameters): Promise<
-    GraphQlQueryResponse
-  >;
+  (query: Query, parameters?: Parameters): Promise<GraphQlQueryResponse>;
 
   /**
    * Returns a new `endpoint` with updated route and parameters

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -12,11 +12,8 @@ export function withDefaults(
   newDefaults: Parameters
 ): ApiInterface {
   const newRequest = request.defaults(newDefaults);
-  const newApi = function<T extends GraphQlQueryResponse>(
-    query: Query | Parameters,
-    options?: Parameters
-  ) {
-    return graphql<T>(newRequest, query, options);
+  const newApi = (query: Query | Parameters, options?: Parameters) => {
+    return graphql(newRequest, query, options);
   };
 
   return Object.assign(newApi, {


### PR DESCRIPTION
@wolfy1339 I updated all dependencies / sub-dependencies and suddenly jest complained about typescript incompatibilities. I removed the Typescript parameters because I frankly did not understand them. Happy to bring them back, would love an explanation :) Just had to get this out of the way so I am no longer blocked on @octokit/core