### PR TITLE
feat(typescript): Allow to pass type params for response data type

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -4,9 +4,9 @@ export class GraphqlError<T extends GraphQlQueryResponse> extends Error {
   public request: Endpoint;
   constructor(
     request: Endpoint,
-    response: { data: Required<GraphQlQueryResponse> }
+    response: { data: T }
   ) {
-    const message = response.data.errors[0].message;
+    const message = response.data.errors![0].message;
     super(message);
 
     Object.assign(this, response.data);

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -11,11 +11,11 @@ const NON_VARIABLE_OPTIONS = [
   "query"
 ];
 
-export function graphql(
+export function graphql<T extends GraphQlQueryResponse>(
   request: typeof Request,
   query: string | Parameters,
   options?: Parameters
-): Promise<GraphQlQueryResponse> {
+) {
   options =
     typeof query === "string"
       ? (options = Object.assign({ query }, options))
@@ -38,13 +38,13 @@ export function graphql(
     {} as Endpoint
   );
 
-  return request(requestOptions).then(response => {
+  return request<T>(requestOptions).then(response => {
     if (response.data.errors) {
       throw new GraphqlError(requestOptions, {
-        data: response.data as Required<GraphQlQueryResponse>
+        data: response.data 
       });
     }
 
-    return response.data.data;
+    return response.data.data as T;
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface graphql {
    *
    * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (options: Parameters): Promise<GraphQlQueryResponse>;
+  <T extends GraphQlQueryResponse>(options: Parameters): Promise<T>;
 
   /**
    * Sends a request based on endpoint options
@@ -17,7 +17,7 @@ export interface graphql {
    * @param {string} route Request method + URL. Example: `'GET /orgs/:org'`
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (query: Query, parameters?: Parameters): Promise<GraphQlQueryResponse>;
+  <T extends GraphQlQueryResponse>(query: Query, parameters?: Parameters): Promise<T>;
 
   /**
    * Returns a new `endpoint` with updated route and parameters

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -12,8 +12,8 @@ export function withDefaults(
   newDefaults: Parameters
 ): ApiInterface {
   const newRequest = request.defaults(newDefaults);
-  const newApi = (query: Query | Parameters, options?: Parameters) => {
-    return graphql(newRequest, query, options);
+  const newApi = <T extends GraphQlQueryResponse>(query: Query | Parameters, options?: Parameters) => {
+    return graphql<T>(newRequest, query, options);
   };
 
   return Object.assign(newApi, {


### PR DESCRIPTION
Fixes #47
Reverts #46