### PR TITLE
docs(types): document query argument in graphql interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,16 +6,17 @@ export type Query = string;
 
 export interface graphql {
   /**
-   * Sends a request based on endpoint options
+   * Sends a GraphQL query request based on endpoint options
+   * The GraphQL query must be specified in `options`.
    *
    * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   (options: Parameters): GraphQlResponse;
 
   /**
-   * Sends a request based on endpoint options
+   * Sends a GraphQL query request based on endpoint options
    *
-   * @param {string} route Request method + URL. Example: `'GET /orgs/:org'`
+   * @param {string} query GraphQL query. Example: `'query { viewer { login } }'`.
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   (query: Query, parameters?: Parameters): GraphQlResponse;


### PR DESCRIPTION
The jsdoc for the `graphql(query, options)` method overload specified the
first argument as a route, when it's really a GraphQL query. This
updates the documentation to reflect that.

This also adds a line to the `graphql(options)` method overload that
specifies that the GraphQL query must be specified in the `options`
parameter. If that's superfluous or could be documented better I'm happy to change it.

![image](https://user-images.githubusercontent.com/2539016/66585372-8c3e4600-eb3b-11e9-9e67-aab7c271b849.png)

Closes #49 