### PR TITLE
feat(typescript): add generic support to graphql 

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,10 +1,10 @@
 import { GraphQlEndpointOptions, GraphQlQueryResponse } from "./types";
 
-export class GraphqlError<T extends GraphQlQueryResponse> extends Error {
+export class GraphqlError<ResponseData> extends Error {
   public request: GraphQlEndpointOptions;
   constructor(
     request: GraphQlEndpointOptions,
-    response: { data: Required<GraphQlQueryResponse> }
+    response: { data: Required<GraphQlQueryResponse<ResponseData>> }
   ) {
     const message = response.data.errors[0].message;
     super(message);

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -17,11 +17,11 @@ const NON_VARIABLE_OPTIONS = [
   "mediaType",
 ];
 
-export function graphql(
+export function graphql<ResponseData = GraphQlQueryResponseData>(
   request: typeof Request,
   query: string | RequestParameters,
   options?: RequestParameters
-): Promise<GraphQlQueryResponseData> {
+): Promise<ResponseData> {
   options =
     typeof query === "string"
       ? (options = Object.assign({ query }, options))
@@ -47,7 +47,7 @@ export function graphql(
   return request(requestOptions).then((response) => {
     if (response.data.errors) {
       throw new GraphqlError(requestOptions, {
-        data: response.data as Required<GraphQlQueryResponse>,
+        data: response.data as Required<GraphQlQueryResponse<ResponseData>>,
       });
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export type GraphQlResponse = ReturnType<typeof graphql>;
 
 export type GraphQlQueryResponseData = {
   [key: string]: any;
-} | null;
+};
 
 export type GraphQlQueryResponse = {
   data: GraphQlQueryResponseData;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface graphql {
    *
    * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (options: RequestParameters): GraphQlResponse;
+  <ResponseData>(options: RequestParameters): GraphQlResponse<ResponseData>;
 
   /**
    * Sends a GraphQL query request based on endpoint options
@@ -28,7 +28,7 @@ export interface graphql {
    * @param {string} query GraphQL query. Example: `'query { viewer { login } }'`.
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (query: Query, parameters?: RequestParameters): GraphQlResponse;
+  <ResponseData>(query: Query, parameters?: RequestParameters): GraphQlResponse<ResponseData>;
 
   /**
    * Returns a new `endpoint` with updated route and parameters
@@ -43,14 +43,14 @@ export interface graphql {
 
 // export type withCustomRequest = (request: typeof Request) => graphql;
 
-export type GraphQlResponse = ReturnType<typeof graphql>;
+export type GraphQlResponse<ResponseData> = Promise<ResponseData>
 
 export type GraphQlQueryResponseData = {
   [key: string]: any;
 };
 
-export type GraphQlQueryResponse = {
-  data: GraphQlQueryResponseData;
+export type GraphQlQueryResponse<ResponseData> = {
+  data: ResponseData;
   errors?: [
     {
       message: string;

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -7,11 +7,11 @@ export function withDefaults(
   newDefaults: RequestParameters
 ): ApiInterface {
   const newRequest = request.defaults(newDefaults);
-  const newApi = (
+  const newApi = <ResponseData>(
     query: Query | RequestParameters,
     options?: RequestParameters
   ) => {
-    return graphql(newRequest, query, options);
+    return graphql<ResponseData>(newRequest, query, options);
   };
 
   return Object.assign(newApi, {


### PR DESCRIPTION
This adds support for an optional generic to the graphql function exported by octokit/@graphql. If no type is passed, the return type will be an object with `string` keys and `any` values.

As far as generic naming goes, I went with `ResponseData`, since I thought it'd be a little more descriptive than `T`,  but I can also change that if that's more aligned with TypeScript conventions.

### Screenshots

<img width="513" alt="image" src="https://user-images.githubusercontent.com/2539016/82402958-951cc180-9a12-11ea-9129-46a3a84a178c.png">

<img width="512" alt="image" src="https://user-images.githubusercontent.com/2539016/82402969-9a7a0c00-9a12-11ea-92e4-8f7e2d70d598.png">

Without a generic
<img width="464" alt="image" src="https://user-images.githubusercontent.com/2539016/82403116-eaf16980-9a12-11ea-96cc-ddd2a03e594f.png">


Closes #80 