### PR TITLE
fix: set error.headers from responses containing a GraphQL error

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,15 +1,17 @@
+import { ResponseHeaders } from '@octokit/types';
 import { GraphQlEndpointOptions, GraphQlQueryResponse } from "./types";
 
 export class GraphqlError<ResponseData> extends Error {
   public request: GraphQlEndpointOptions;
   constructor(
     request: GraphQlEndpointOptions,
-    response: { data: Required<GraphQlQueryResponse<ResponseData>> }
+    response: { headers: ResponseHeaders, data: Required<GraphQlQueryResponse<ResponseData>> }
   ) {
     const message = response.data.errors[0].message;
     super(message);
 
     Object.assign(this, response.data);
+    Object.assign(this, { headers: response.headers });
     this.name = "GraphqlError";
     this.request = request;
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,4 +1,5 @@
 import { request as Request } from "@octokit/request";
+import { ResponseHeaders } from "@octokit/types";
 import { GraphqlError } from "./error";
 import {
   GraphQlEndpointOptions,
@@ -46,7 +47,13 @@ export function graphql<ResponseData = GraphQlQueryResponseData>(
 
   return request(requestOptions).then((response) => {
     if (response.data.errors) {
+      const headers: ResponseHeaders = {};
+      for (const key of Object.keys(response.headers)) {
+          headers[key] = response.headers[key]
+      }
+
       throw new GraphqlError(requestOptions, {
+        headers,
         data: response.data as Required<GraphQlQueryResponse<ResponseData>>,
       });
     }

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -94,7 +94,12 @@ describe("errors", () => {
       request: {
         fetch: fetchMock
           .sandbox()
-          .post("https://api.github.com/graphql", mockResponse),
+          .post("https://api.github.com/graphql", { 
+            body: mockResponse,
+            headers: {
+              'x-github-request-id': 'C5E6:259A:1351B40:2E88B87:5F1F9C41'
+            }
+          }),
       },
     })
       .then((result) => {
@@ -107,6 +112,8 @@ describe("errors", () => {
         expect(error.errors).toStrictEqual(mockResponse.errors);
         expect(error.request.query).toEqual(query);
         expect(error.data).toStrictEqual(mockResponse.data);
+        expect(error.headers).toHaveProperty('x-github-request-id');
+        expect(error.headers['x-github-request-id']).toEqual('C5E6:259A:1351B40:2E88B87:5F1F9C41');
       });
   });
 


### PR DESCRIPTION
This fixes #158.

After this change, the exception thrown has this structure:

```json
{
  "errors": [
    {
      "path": ["query", "viewer", "bioHtm"],
      "extensions": {
        "code": "undefinedField",
        "typeName": "User",
        "fieldName": "bioHtm"
      },
      "locations": [{ "line": 4, "column": 11 }],
      "message": "Field 'bioHtm' doesn't exist on type 'User'"
    }
  ],
  "headers": {
    "access-control-allow-origin": "*",
    "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
    "cache-control": "no-cache",
    "connection": "close",
    "content-encoding": "gzip",
    "content-security-policy": "default-src 'none'",
    "content-type": "application/json; charset=utf-8",
    "date": "Tue, 28 Jul 2020 03:32:17 GMT",
    "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
    "server": "GitHub.com",
    "status": "200 OK",
    "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
    "transfer-encoding": "chunked",
    "vary": "Accept-Encoding, Accept, X-Requested-With",
    "x-accepted-oauth-scopes": "repo",
    "x-content-type-options": "nosniff",
    "x-frame-options": "deny",
    "x-github-media-type": "github.v3; format=json",
    "x-github-request-id": "C5E6:259A:1351B40:2E88B87:5F1F9C41",
    "x-oauth-scopes": "repo",
    "x-ratelimit-limit": "5000",
    "x-ratelimit-remaining": "5000",
    "x-ratelimit-reset": "1595910737",
    "x-xss-protection": "1; mode=block"
  },
  "name": "GraphqlError",
  "request": {
    "query": "\n      {\n        viewer {\n          bioHtm\n        }\n      }\n    "
  }
}
```