### PR TITLE
fix: syntax error in the code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,10 @@ const { lastIssues } = await graphql(`query lastIssues($owner: String!, $repo: S
     }
   }`, {
     owner: 'octokit',
-    repo: 'graphql.js'
+    repo: 'graphql.js',
     headers: {
       authorization: `token secret123`
     }
-  }
 })
 ```
 
@@ -175,7 +174,7 @@ const { lastIssues } = await graphql({
     }
   }`,
   owner: 'octokit',
-  repo: 'graphql.js'
+  repo: 'graphql.js',
   headers: {
     authorization: `token secret123`
   }


### PR DESCRIPTION
There're some syntax error caused by missing comma or extra bracket in the readme. This PR fixes that.