### PR TITLE
fix: throw helpful error in case "query", "url", or "method" is used as query variable

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -18,6 +18,8 @@ const NON_VARIABLE_OPTIONS = [
   "mediaType",
 ];
 
+const FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
+
 const GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
 
 export function graphql<ResponseData = GraphQlQueryResponseData>(
@@ -25,10 +27,20 @@ export function graphql<ResponseData = GraphQlQueryResponseData>(
   query: string | RequestParameters,
   options?: RequestParameters
 ): Promise<ResponseData> {
-  if (typeof query === "string" && options && "query" in options) {
-    return Promise.reject(
-      new Error(`[@octokit/graphql] "query" cannot be used as variable name`)
-    );
+  if (options) {
+    if (typeof query === "string" && "query" in options) {
+      return Promise.reject(
+        new Error(`[@octokit/graphql] "query" cannot be used as variable name`)
+      );
+    }
+
+    for (const key in options) {
+      if (!FORBIDDEN_VARIABLE_OPTIONS.includes(key)) continue;
+
+      return Promise.reject(
+        new Error(`[@octokit/graphql] "${key}" cannot be used as variable name`)
+      );
+    }
   }
 
   const parsedOptions =

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -231,4 +231,44 @@ describe("graphql()", () => {
       );
     });
   });
+
+  it("url variable (#264)", () => {
+    expect.assertions(1);
+
+    const query = `query GetCommitStatus($url: URI!) {
+      resource(url: $url) {
+        ... on Commit {
+          status {
+            state
+          }
+        }
+      }
+    }`;
+
+    return graphql(query, {
+      url: "https://example.com",
+    }).catch((error) => {
+      expect(error.message).toEqual(
+        `[@octokit/graphql] "url" cannot be used as variable name`
+      );
+    });
+  });
+
+  it("method variable", () => {
+    expect.assertions(1);
+
+    const query = `query($method:String!){
+      search(query:$method,type:ISSUE) {
+        codeCount
+      }
+    }`;
+
+    return graphql(query, {
+      method: "test",
+    }).catch((error) => {
+      expect(error.message).toEqual(
+        `[@octokit/graphql] "method" cannot be used as variable name`
+      );
+    });
+  });
 });


### PR DESCRIPTION
fixes #265