### PR TITLE
feat(typescript): expose `type` property for errors in graphql response errors

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type GraphQlQueryResponse<ResponseData> = {
   data: ResponseData;
   errors?: [
     {
+      type: string;
       message: string;
       path: [string];
       extensions: { [key: string]: any };

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type GraphQlQueryResponse<ResponseData> = {
   data: ResponseData;
   errors?: [
     {
+      // https://github.com/octokit/graphql.js/pull/314
       type: string;
       message: string;
       path: [string];


### PR DESCRIPTION
GraphQL response errors can have a `type` field that can be useful
for error detection. e.g. if a pull request does not exist there is
an error with the `NOT_FOUND` type.

@gr2m maybe you could help with this here. I have not found any official specification from Github on this, but I see feature requests for this in other Github GraphQL libraries and I can see it in various requests from Github. We could also type this as potentially `undefined`? I lack information here unfortunately.