### PR TITLE
ci(codeql): ignore on push events for dependabot branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,8 @@ name: "Code scanning - action"
 on:
   push:
   pull_request:
+    branches-ignore:
+      - "dependabot/**"
   schedule:
     - cron: '0 19 * * 0'
 


### PR DESCRIPTION
# Description
Do not run codeql.yml for dependabot branches

# Context
https://github.com/octokit/plugin-paginate-rest.js/pull/376