### PR TITLE
fix(docs): refer to `Authorization` header in the README, not `Authentication`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ const { withCustomRequest } = require("@octokit/graphql");
 let requestCounter = 0;
 const myRequest = request.defaults({
   headers: {
-    authentication: "token secret123",
+    authorization: "bearer secret123",
   },
   request: {
     hook(request, options) {


### PR DESCRIPTION
The correct name of the header is 'Authorization' and not 'Authentication'. 

Tested with: 

```
curl -H "Authorization: bearer {edited}" -X POST -d " \
 { \
   \"query\": \"query { viewer { login }}\" \
 } \
" https://api.github.com/graphql
```

Previously:
```
$ curl -H "Authentication: bearer {edited}" -X POST -d " \
 { \
   \"query\": \"query { viewer { login }}\" \
 } \
" https://api.github.com/graphql
{
  "message": "This endpoint requires you to be authenticated.",
  "documentation_url": "https://docs.github.com/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql"
}
```