### PR TITLE
refactor: use `node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,5 @@
 import type { ResponseHeaders } from "@octokit/types";
-import type { GraphQlEndpointOptions, GraphQlQueryResponse } from "./types";
+import type { GraphQlEndpointOptions, GraphQlQueryResponse } from "./types.js";
 
 type ServerResponseData<T> = Required<GraphQlQueryResponse<T>>;
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,12 +1,12 @@
 import { request as Request } from "@octokit/request";
 import type { ResponseHeaders } from "@octokit/types";
-import { GraphqlResponseError } from "./error";
+import { GraphqlResponseError } from "./error.js";
 import type {
   GraphQlEndpointOptions,
   RequestParameters,
   GraphQlQueryResponse,
   GraphQlQueryResponseData,
-} from "./types";
+} from "./types.js";
 
 const NON_VARIABLE_OPTIONS = [
   "method",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { request } from "@octokit/request";
 import { getUserAgent } from "universal-user-agent";
 
-import { VERSION } from "./version";
+import { VERSION } from "./version.js";
 
-import { withDefaults } from "./with-defaults";
+import { withDefaults } from "./with-defaults.js";
 
 export const graphql = withDefaults(request, {
   headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type {
   EndpointInterface,
 } from "@octokit/types";
 
-import { graphql } from "./graphql";
+import type { graphql } from "./graphql.js";
 
 export type GraphQlEndpointOptions = EndpointOptions & {
   variables?: { [key: string]: unknown };

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -3,8 +3,8 @@ import type {
   graphql as ApiInterface,
   Query,
   RequestParameters,
-} from "./types";
-import { graphql } from "./graphql";
+} from "./types.js";
+import { graphql } from "./graphql.js";
 
 export function withDefaults(
   request: typeof Request,

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.