### PR TITLE
fix(pkg): add `main` entry point

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -65,7 +65,9 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
-       exports: {
+        main: "./dist-bundle/index.js",
+        types: "./dist-types/index.d.ts",
+        exports: {
           ".": {
             types: "./dist-types/index.d.ts",
             import: "./dist-bundle/index.js",


### PR DESCRIPTION
Some tools don't play well with only having the `exports` field present.

See octokit/core.js#662