### PR TITLE
feat: support TypedDocumentString as query argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,46 @@ Additionally, `GraphQlQueryResponseData` has been exposed to users:
 import type { GraphQlQueryResponseData } from "@octokit/graphql";
 ```
 
+### Usage with graphql-codegen
+
+If your query is represented as a `String & DocumentTypeDecoration`, for example as [`TypedDocumentString` from graphql-codegen and its client preset](https://the-guild.dev/graphql/codegen/docs/guides/vanilla-typescript), then you can get type-safety for the query's parameters and return values.
+
+Assuming you have configured graphql-codegen, with [GitHub's GraphQL schema](https://docs.github.com/en/graphql/overview/public-schema), and an output under `./graphql`:
+
+```tsx
+import * as octokit from "@octokit/graphql";
+
+// The graphql query factory from graphql-codegen's output
+import { graphql } from "./graphql/graphql.js";
+
+const result = await octokit.graphql(
+  graphql`
+    query lastIssues($owner: String!, $repo: String!, $num: Int = 3) {
+      repository(owner: $owner, name: $repo) {
+        issues(last: $num) {
+          edges {
+            node {
+              title
+            }
+          }
+        }
+      }
+    }
+  `,
+  {
+    owner: "octokit",
+    repo: "graphql.js",
+    headers: {
+      authorization: `token secret123`,
+    },
+  },
+  // ^ parameters are required; owner and repo are type-checked
+);
+
+type Return = typeof result;
+//   ^? { repository: {issues: {edges: Array<{node: {title: string}>}} }
+```
+
 ## Errors
 
 In case of a GraphQL error, `error.message` is set to a combined message describing all errors returned by the endpoint.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
         "@octokit/request": "^9.1.4",
         "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
@@ -524,6 +525,14 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1478,6 +1487,15 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/graphql": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "license": "MIT",
   "dependencies": {
+    "@graphql-typed-document-node/core": "^3.2.0",
     "@octokit/request": "^9.1.4",
     "@octokit/types": "^13.6.2",
     "universal-user-agent": "^7.0.0"

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import type {
   EndpointInterface,
 } from "@octokit/types";
 
+import type { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
+
 import type { graphql } from "./graphql.js";
 
 export type GraphQlEndpointOptions = EndpointOptions & {
@@ -31,6 +33,25 @@ export interface graphql {
   <ResponseData>(
     query: Query,
     parameters?: RequestParameters,
+  ): GraphQlResponse<ResponseData>;
+
+  /**
+   * Sends a GraphQL query request based on endpoint options. The query parameters are type-checked
+   *
+   * @param {String & DocumentTypeDecoration<ResponseData, QueryVariables>} query GraphQL query. Example: `'query { viewer { login } }'`.
+   * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
+   */
+  <ResponseData, QueryVariables>(
+    query: String & DocumentTypeDecoration<ResponseData, QueryVariables>,
+    /**
+     * The tuple in rest parameters allows makes RequestParameters conditionally
+     * optional , if the query does not require any variables.
+     *
+     * @see https://github.com/Microsoft/TypeScript/pull/24897#:~:text=not%20otherwise%20observable).-,Optional%20elements%20in%20tuple%20types,-Tuple%20types%20now
+     */
+    ...[parameters]: QueryVariables extends Record<string, never>
+      ? [RequestParameters?]
+      : [QueryVariables & RequestParameters]
   ): GraphQlResponse<ResponseData>;
 
   /**

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -5,6 +5,18 @@ import type {
   RequestParameters,
 } from "./types.js";
 import { graphql } from "./graphql.js";
+import type { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
+
+/**
+ * Allows discarding the DocumentTypeDecoration information from the external
+ * interface, and casting the String part to string. This avoids the external
+ * API interface spreading to the internal types, while keeping type-safety for
+ * future extensions/changes.
+ */
+type DiscardTypeDecoration<T> = T extends String &
+  DocumentTypeDecoration<unknown, unknown>
+  ? string
+  : T;
 
 export function withDefaults(
   request: typeof Request,
@@ -12,10 +24,17 @@ export function withDefaults(
 ): ApiInterface {
   const newRequest = request.defaults(newDefaults);
   const newApi = <ResponseData>(
-    query: Query | RequestParameters,
+    query:
+      | Query
+      | (String & DocumentTypeDecoration<unknown, unknown>)
+      | RequestParameters,
     options?: RequestParameters,
   ) => {
-    return graphql<ResponseData>(newRequest, query, options);
+    return graphql<ResponseData>(
+      newRequest,
+      query as DiscardTypeDecoration<typeof query>,
+      options,
+    );
   };
 
   return Object.assign(newApi, {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,14 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    // TODO: This setting is not compatible with the default definition of
+    // DocumentTypeDecoration from '@graphql-codegen-types/core'. That
+    // definition includes `{__apiType?: ...}` as an optional, so assigning it
+    // to an explicit `undefined` is impossible under
+    // exactOptionalPropertyTypes. We only need to work around this in tests,
+    // since that is where we use concrete examples of DocumentTypeDecoration.
+    "exactOptionalPropertyTypes": false
   },
   "include": ["src/**/*"]
 }

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "allowImportingTsExtensions": true,
     // TODO: This setting is not compatible with the default definition of
-    // DocumentTypeDecoration from '@graphql-codegen-types/core'. That
+    // DocumentTypeDecoration from '@graphql-typed-document-node/core'. That
     // definition includes `{__apiType?: ...}` as an optional, so assigning it
     // to an explicit `undefined` is impossible under
     // exactOptionalPropertyTypes. We only need to work around this in tests,


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #596

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Prior to this, one could use `TypedDocumentString` with `graphql-codegen`, but would have to write their own wrapper around `graphql`, in order to ensure type-safety. This is not a big deal to be honest, but having support out of the box simplifies ergonomics. 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* After this change, one additional override has been added to the public API interface. It allows providing a query as `String & DocumentTypeDecoration<ResponseData, QueryVariables>`. This the definition of `TypedDocumentString` from `graphql-codegen`/ [graphql-typed-document-node](https://github.com/dotansimha/graphql-typed-document-node). `DocumentTypeDecoration` itself is the lowest common denominator for type-safety in that ecosystem. If the user provides such a query, then we can have type-safety for the query parameters and return value.
* There are some shortcomings of this approach, which I will list below 🗒️ 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

This is not a breaking change. The API did not accept plain `TypedDocumentString`s previously, whereas now it does. I also took care to with the interface overrides, to preserve `RequestParameters` as optional, unless the query is a `TypedDocumentString` with required variables.

Aside: I would be happy to contribute a few type-only tests for the public API interface. The overrides can lead to subtle changes, and I've found type-only tests to be useful to catch regressions in similar projects.

----

## Open remarks

I am not fully happy with the shape here, and I have considered a couple of alternatives, that I could use your input on 👀 

### Lack of a shared `TypedDocumentString` type

The first issue is that `graphql-codegen` does not expose a shared `TypedDocumentString` type from its core types, but rather inlines it in the codegen output. The type has a runtime representation (as a class), so it is a bit more complicated than the type-only `TypedDocumentNode`. This is discussed both in [the original issue](https://github.com/octokit/graphql.js/issues/596) and [a follow-up issue in graphql-typed-document-node](https://github.com/dotansimha/graphql-typed-document-node/issues/163).

The type `String & DocumentTypeDecoration` works well-enough, because `DocumentTypeDecoration` has the actionable types, but that means that the contract between this library and graphql-codegen output is less explicit. Alternative tools do not have access to `TypedDocumentString` the same way that they have access to `TypedDocumentNode`.

### `String & DocumentTypeDecoration` vs `string & DocumentTypeDecoration`

Partly due to the lack of a shared type, and partly because of the runtime class representation, we are currently doing a not-as-nice `String.prototype.isPrototypeOf` check to duck-type the `TypedDocumentString`, and call `.toString()` on it. This could be nicer with a `typeof` check, but that is only part of my hesitation.

An alternative would be to use `string & DocumentTypeDecoration` as the interface.

In practice, this means that instead of this:

```tsx
graphql(someTypedDocumentString, {/* params */})
```

...the caller would have to do:

```tsx
graphql(someTypedDocumentString.toString(), {/* params */})
```

This simplifies the internal implementation and reliance on the runtime representation of `TypedDocumentString`, at the cost of some developer ergonomics.

I might be overthinking this; I would be happy to implement it/document it whichever way you prefer 😇 

### Missing one implementation overload

This one is small: I did not implement a `TypedDocumentString` overload for the query-as-request-parameter API shape. I am happy to implement it, but first I would like feedback on the above points, before going down that rabbit hole 😅 

These are all the open discussion points that I can think of. Please let me know if there is any other information that I can provide, and I'll get back to you. And thank you for all your work on octokit; it's been a joy to use over the years!