### PR TITLE
Allow users to specify `operationName` in multi-operation queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^9.1.4",
-        "@octokit/types": "^13.6.2",
+        "@octokit/types": "^13.8.0",
         "universal-user-agent": "^7.0.0"
       },
       "devDependencies": {
@@ -665,9 +665,9 @@
       "license": "MIT"
     },
     "node_modules/@octokit/types": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
-      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@octokit/request": "^9.1.4",
-    "@octokit/types": "^13.6.2",
+    "@octokit/types": "^13.8.0",
     "universal-user-agent": "^7.0.0"
   },
   "devDependencies": {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -16,6 +16,7 @@ const NON_VARIABLE_OPTIONS = [
   "request",
   "query",
   "mediaType",
+  "operationName",
 ];
 
 const FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];

--- a/test/defaults.test.ts
+++ b/test/defaults.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import fetchMock from "fetch-mock";
+import fetchMock, { type CallLog } from "fetch-mock";
 import { getUserAgent } from "universal-user-agent";
 
 import { VERSION } from "../src/version";
@@ -213,5 +213,119 @@ describe("graphql.defaults()", () => {
         "user-agent": userAgent,
       },
     });
+  });
+
+  it("Allows user to specify non variable options", () => {
+    const mockData = {
+      repository: {
+        issues: {
+          edges: [
+            {
+              node: {
+                title: "Foo",
+              },
+            },
+            {
+              node: {
+                title: "Bar",
+              },
+            },
+            {
+              node: {
+                title: "Baz",
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const query = /* GraphQL */ `
+        query Blue($last: Int) {
+          repository(owner: "blue", name: "graphql.js") {
+            issues(last: $last) {
+              edges {
+                node {
+                  title
+                }
+              }
+            }
+          }
+        }
+
+        query Green($last: Int) {
+          repository(owner: "green", name: "graphql.js") {
+            issues(last: $last) {
+              edges {
+                node {
+                  title
+                }
+              }
+            }
+          }
+        }
+        `.trim();
+
+    const fetch = fetchMock.createInstance();
+
+    fetch.post(
+      "https://api.github.com/graphql",
+      { data: mockData },
+      {
+        method: "POST",
+        headers: {
+          accept: "application/vnd.github.v3+json",
+          authorization: "token secret123",
+          "user-agent": userAgent,
+        },
+        matcherFunction: (callLog: CallLog) => {
+          const expected = {
+            query: query,
+            operationName: "Blue",
+            variables: { last: 3 },
+          };
+          const result = callLog.options.body === JSON.stringify(expected);
+          if (!result) {
+            console.warn("Body did not match expected value", {
+              expected,
+              actual: JSON.parse(callLog.options.body as string),
+            });
+          }
+          return result;
+        },
+      },
+    );
+
+    const authenticatedGraphql = graphql.defaults({
+      headers: {
+        authorization: `token secret123`,
+      },
+      request: {
+        fetch: fetch.fetchHandler,
+      },
+    });
+
+    return new Promise<void>((res, rej) =>
+      authenticatedGraphql({
+        query,
+        headers: {
+          authorization: `token secret123`,
+        },
+        request: {
+          fetch: fetch.fetchHandler,
+        },
+        operationName: "Blue",
+        last: 3,
+      })
+        .then((result) => {
+          expect(JSON.stringify(result)).toStrictEqual(
+            JSON.stringify(mockData),
+          );
+          res();
+        })
+        .catch(() => {
+          rej("Should have resolved");
+        }),
+    );
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #406

Related types PR: https://github.com/octokit/types.ts/pull/662

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* It was not possible to send a query with multiple operations

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Sending a query with multiple operations
* Specifying to the server which operation to use

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

